### PR TITLE
adding a new query, --antiaffinityrules

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ class VCTools(Logger):
                     [vim.ClusterComputeResource], True
                 )
 
-                if self.opts.antiaffinityrules:
+                if self.opts.anti_affinity_rules:
                     if self.opts.cluster:
                         antiaffinityrules = Query.return_antiaffinityrules(
                             clusters_container.view, self.opts.cluster

--- a/main.py
+++ b/main.py
@@ -124,20 +124,42 @@ class VCTools(Logger):
                 )
                 clusters_container = Query.create_container(
                     self.auth.session, self.auth.session.content.rootFolder,
-                    [vim.ComputeResource], True
+                    [vim.ClusterComputeResource], True
                 )
+
+                if self.opts.antiaffinityrules:
+                    if self.opts.cluster:
+                        antiaffinityrules = Query.return_antiaffinityrules(
+                            clusters_container.view, self.opts.cluster
+                        )
+                    else:
+                        cluster = Prompts.clusters(self.auth.session)
+                        antiaffinityrules = Query.return_antiaffinityrules(
+                            clusters_container.view, cluster
+                        )
+
+                    if not antiaffinityrules:
+                        print('No antiaffinity rules defined.')
+                    else:
+                        print('Antiaffinity rules:')
+                        for rule in antiaffinityrules:
+                            print(rule[0], end=':')
+                            for i in range(1, len(rule)):
+                                print('\t', end='')
+                                print(rule[i], end='')
+                            print()
+
                 if self.opts.datastores:
                     if self.opts.cluster:
                         datastores = Query.return_datastores(
                             clusters_container.view, self.opts.cluster
                         )
-                        for row in datastores:
-                            print('{0:30}\t{1:10}\t{2:10}\t{3:6}\t{4:10}\t{5:6}'.format(*row))
                     else:
                         cluster = Prompts.clusters(self.auth.session)
                         datastores = Query.return_datastores(clusters_container.view, cluster)
-                        for row in datastores:
-                            print('{0:30}\t{1:10}\t{2:10}\t{3:6}\t{4:10}\t{5:6}'.format(*row))
+                    for row in datastores:
+                        print('{0:30}\t{1:10}\t{2:10}\t{3:6}\t{4:10}\t{5:6}'.format(*row))
+
                 if self.opts.folders:
                     if self.opts.datacenter:
                         folders = Query.list_vm_folders(

--- a/main.py
+++ b/main.py
@@ -137,17 +137,13 @@ class VCTools(Logger):
                         antiaffinityrules = Query.return_antiaffinityrules(
                             clusters_container.view, cluster
                         )
-
                     if not antiaffinityrules:
                         print('No antiaffinity rules defined.')
                     else:
                         print('Antiaffinity rules:')
-                        for rule in antiaffinityrules:
-                            print(rule[0], end=':')
-                            for i in range(1, len(rule)):
-                                print('\t', end='')
-                                print(rule[i], end='')
-                            print()
+
+                        for key, val in antiaffinityrules.iteritems():
+                            print('{0} : {1}'.format(key, '\t'.join(val)))
 
                 if self.opts.datastores:
                     if self.opts.cluster:

--- a/vctools/argparser.py
+++ b/vctools/argparser.py
@@ -292,7 +292,7 @@ class ArgParser(Logger):
         query_opts = query_parser.add_argument_group('query options')
 
         query_opts.add_argument(
-            '--antiaffinityrules', action='store_true',
+            '--anti-affinity-rules', action='store_true',
             help='Returns information about AntiAffinityRules.'
         )
 

--- a/vctools/argparser.py
+++ b/vctools/argparser.py
@@ -292,6 +292,11 @@ class ArgParser(Logger):
         query_opts = query_parser.add_argument_group('query options')
 
         query_opts.add_argument(
+            '--antiaffinityrules', action='store_true',
+            help='Returns information about AntiAffinityRules.'
+        )
+
+        query_opts.add_argument(
             '--datastores', action='store_true',
             help='Returns information about Datastores.'
         )

--- a/vctools/query.py
+++ b/vctools/query.py
@@ -229,7 +229,7 @@ class Query(Logger):
         """
 
         cluster_obj = Query.get_obj(container, cluster)
-        antiaffinityrules = []
+        antiaffinityrules = {}
 
         if hasattr(cluster_obj, 'configuration'):
             if hasattr(cluster_obj.configuration, 'rule'):
@@ -237,13 +237,12 @@ class Query(Logger):
 
                     if isinstance(rule, vim.cluster.AntiAffinityRuleSpec):
 
-                        aa_rule = []
-                        # first entry in the aa_rule list will always be name, next is VMs
-                        aa_rule.append(rule.name)
+                        aa_vms = []
                         if hasattr(rule, 'vm'):
                             for rule_vm in rule.vm:
-                                aa_rule.append(rule_vm.name)
-                        antiaffinityrules.append(aa_rule)
+                                aa_vms.append(rule_vm.name)
+                        aa_rule = {rule.name : aa_vms}
+                        antiaffinityrules.update(aa_rule)
 
             return antiaffinityrules
         return None

--- a/vctools/query.py
+++ b/vctools/query.py
@@ -219,6 +219,37 @@ class Query(Logger):
 
 
     @classmethod
+    def return_antiaffinityrules(cls, container, cluster):
+        """
+        Returns antiaffinity rules
+
+        Args:
+            container (obj): Container object
+            cluster (str):   Name of cluster
+        """
+
+        cluster_obj = Query.get_obj(container, cluster)
+        antiaffinityrules = []
+
+        if hasattr(cluster_obj, 'configuration'):
+            if hasattr(cluster_obj.configuration, 'rule'):
+                for rule in cluster_obj.configuration.rule:
+
+                    if isinstance(rule, vim.cluster.AntiAffinityRuleSpec):
+
+                        aa_rule = []
+                        # first entry in the aa_rule list will always be name, next is VMs
+                        aa_rule.append(rule.name)
+                        if hasattr(rule, 'vm'):
+                            for rule_vm in rule.vm:
+                                aa_rule.append(rule_vm.name)
+                        antiaffinityrules.append(aa_rule)
+
+            return antiaffinityrules
+        return None
+
+
+    @classmethod
     def list_vm_info(cls, container, datacenter):
         """
         Returns a list of names for VMs located inside a datacenter.


### PR DESCRIPTION
It will display antiaffinity rules for cluster, in the format:

rulename: vm1 vm2 vm3 etc

the line is tab separated.

It works like other cluster queries such as datastores, where you can either specify
--cluster=foo ahead of time, or it will ask for the cluster