### PR TITLE
add the ability to create a new AntiAffnity rule

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from pyVmomi import vim # pylint: disable=no-name-in-module
 from vctools.argparser import ArgParser
 from vctools.auth import Auth
 from vctools.vmconfig_helper import VMConfigHelper
+from vctools.clusterconfig import ClusterConfig
 from vctools.prompts import Prompts
 from vctools.query import Query
 from vctools.cfgchecker import CfgCheck
@@ -30,6 +31,7 @@ class VCTools(Logger):
         self.opts = opts
         self.auth = None
         self.vmcfg = None
+        self.clustercfg = None
 
     def main(self):
         """
@@ -54,6 +56,7 @@ class VCTools(Logger):
             )
 
             self.vmcfg = VMConfigHelper(self.auth, self.opts, argparser.dotrc)
+            self.clustercfg = ClusterConfig(self.auth, self.opts, argparser.dotrc)
 
             call_count = self.auth.session.content.sessionManager.currentSession.callCount
 
@@ -116,6 +119,19 @@ class VCTools(Logger):
                     self.vmcfg.disk_recfg()
                 if self.opts.device == 'nic':
                     self.vmcfg.nic_recfg()
+
+            if self.opts.cmd == 'add-aa-rule':
+                if not self.opts.cluster:
+                    raise ValueError('Error: cluster required')
+                if not self.opts.name:
+                    raise ValueError('Error: name required')
+                if not self.opts.vms:
+                    raise ValueError('Error: vms required')
+                if len(self.opts.vms) == 1:
+                    raise ValueError('Error: more than one vm must be specified')
+                #print('In add_aa_rule')
+                #print(self.opts.vms)
+                self.clustercfg.add_aa_rule()
 
             if self.opts.cmd == 'query':
                 datacenters_container = Query.create_container(

--- a/vctools/argparser.py
+++ b/vctools/argparser.py
@@ -505,6 +505,26 @@ class ArgParser(Logger):
         if defaults:
             upload_parser.set_defaults(**defaults)
 
+    def add_aa_rule(self, *parents):
+        """ Adding an anti affinity rule"""
+        add_aa_rule_parser = self.subparsers.add_parser(
+            'add-aa-rule', parents=list(parents),
+            help='Adds an AntiAffinity rule to a cluster'
+        )
+        add_aa_rule_parser.set_defaults(cmd='add-aa-rule')
+        add_aa_rule_parser.add_argument(
+            '--name', metavar='', type=str,
+            help='Name of the new AntiAffinity Rule'
+        )
+        add_aa_rule_parser.add_argument(
+            '--vms', nargs='+', metavar='', type=str,
+            help='VMs to be added to AntiAffinity Rule'
+        )
+        add_aa_rule_parser.add_argument(
+            '--cluster', metavar='',
+            help='vCenter ComputeResource.'
+        )
+
     def sanitize(self, opts):
         """
         Sanitize arguments. This will override the user / config input to a supported state.
@@ -554,7 +574,8 @@ class ArgParser(Logger):
         parent_parsers = ['general', 'logging']
         parents = []
 
-        subparsers = ['add', 'create', 'mount', 'power', 'query', 'reconfig', 'umount', 'upload']
+        subparsers = ['add', 'create', 'mount', 'power', 'query', 'reconfig', 'umount',
+                      'upload', 'add_aa_rule']
 
         try:
             # load parsers using defaults

--- a/vctools/clusterconfig.py
+++ b/vctools/clusterconfig.py
@@ -1,0 +1,96 @@
+"""Various config options for Virtual Machines."""
+#!/usr/bin/python
+# vim: ts=4 sw=4 et
+from __future__ import print_function
+from __future__ import division
+from pyVmomi import vim # pylint: disable=E0611
+from vctools.query import Query
+from vctools.vmconfig import VMConfig
+from vctools import Logger
+
+class ClusterConfig(VMConfig, Logger):
+    """Various config options for Virtual Machines."""
+    def __init__(self, auth, opts, dotrc):
+        self.auth = auth
+        self.opts = opts
+        self.dotrc = dotrc
+        self.datacenters = Query.create_container(
+            self.auth.session, self.auth.session.content.rootFolder,
+            [vim.Datacenter], True
+        )
+        self.clusters = Query.create_container(
+            self.auth.session, self.auth.session.content.rootFolder,
+            [vim.ComputeResource], True
+        )
+        self.folders = Query.create_container(
+            self.auth.session, self.auth.session.content.rootFolder,
+            [vim.Folder], True
+        )
+        self.virtual_machines = Query.create_container(
+            self.auth.session, self.auth.session.content.rootFolder,
+            [vim.VirtualMachine], True
+        )
+        # stealing task_monitor from VMConfig
+        VMConfig.__init__(self)
+
+
+    def add_aa_rule(self):
+        """Add an AntiAffinity Rule"""
+
+        cluster = self.opts.cluster
+        rule_name_raw = self.opts.name
+        vms_raw = self.opts.vms
+        self.logger.debug(cluster, rule_name_raw, vms_raw)
+
+        # if name doesn't start with vctools-, make it
+        if rule_name_raw.startswith('vctools-'):
+            rule_name = rule_name_raw
+        else:
+            rule_name = 'vctools-' + rule_name_raw
+
+        vm_obj_list = []
+        for vm_obj in vms_raw:
+            vm_obj_list.append(Query.get_obj(self.virtual_machines.view, vm_obj))
+        cluster_obj = Query.get_obj(self.clusters.view, cluster)
+
+        # check to see if this rule name is in use
+        for existing_rule in cluster_obj.configuration.rule:
+            if existing_rule.name == rule_name:
+                raise ValueError('Error: rule name "%s" is already in use' % rule_name)
+
+        # check to see vms are in the right cluster
+        for vm_obj in vm_obj_list:
+            match = 0
+            for clus_vm in cluster_obj.resourcePool.vm:
+                if vm_obj == clus_vm:
+                    #print('found match: ', vm_obj)
+                    match = 1
+            if match == 0:
+                raise ValueError('Error: the vm "%s" is not in the stated cluster' % vm_obj.name)
+
+        # check to see if the vms already have DRS rules
+        for vm_obj in vm_obj_list:
+            match = 0
+            for rule in cluster_obj.configuration.rule:
+                if hasattr(rule, 'vm'):
+                    for rulevm in rule.vm:
+                        if vm_obj == rulevm:
+                            match = 1
+            if match != 0:
+                raise ValueError('Error: the vm "%s" is already in a DRS rule' % vm_obj.name)
+
+        new_rule = vim.ClusterAntiAffinityRuleSpec()
+        new_rule.name = rule_name
+
+        new_rule.userCreated = True
+        new_rule.enabled = True
+        for vm_obj in vm_obj_list:
+            new_rule.vm.append(vm_obj)
+
+        #do the needful
+        rule_spec = vim.cluster.RuleSpec(info=new_rule, operation='add')
+        config_spec = vim.cluster.ConfigSpecEx(rulesSpec=[rule_spec])
+        self.task_monitor(cluster_obj.ReconfigureComputeResource_Task(
+            config_spec, modify=True), False)
+
+        self.logger.info('new AA DRS rule on %s: %s', cluster, rule_name)


### PR DESCRIPTION
I added some checks to make sure we don't do anything dumb

-rules will always start with 'vctools-'
-names of rules can't be reused (VCenter doesn't seem to care)
-VMs in existing affinity/antiaffinity rules can't be placed into new ones.