### PR TITLE
DRS rule bugfix

### DIFF
--- a/vctools/argparser.py
+++ b/vctools/argparser.py
@@ -575,6 +575,8 @@ class ArgParser(Logger):
         """
         # DRS rule names should always begin with the prefix
         if opts.cmd == 'drs':
+            if not opts.prefix:
+                opts.prefix = self.dotrc['clusterconfig']['prefix']
             if not opts.name.startswith(opts.prefix):
                 opts.name = opts.prefix + opts.name
 


### PR DESCRIPTION
A bug was introduced when the DRS 'is the prefix inluded in rule
name' test was moved to the sanitize part of argparser.  It worked
fine with command line prefix, but failed with vctoolsrc prefix.
This fixes that.